### PR TITLE
Collapse file open operations

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -81,10 +81,7 @@ impl Cache {
         table_id: TableIdentifier,
         handle: Rc<TableReadHandle>,
     ) -> Result<()> {
-        let outdated = self.handle_cache.borrow_mut().put(table_id, handle);
-        if let Some(handle) = outdated {
-            handle.try_close().await?;
-        }
+        self.handle_cache.borrow_mut().put(table_id, handle);
 
         Ok(())
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,6 @@ use crate::file::FileManager;
 use crate::fn_registry::FnRegistry;
 
 pub struct Context {
-    pub file_manager: FileManager,
+    crate file_manager: FileManager,
     pub fn_registry: FnRegistry,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,7 +93,7 @@ pub(crate) struct HelixCore {
 
 impl HelixCore {
     fn new<P: AsRef<Path>>(path: P, mut opts: Options) -> Self {
-        let file_manager = FileManager::with_base_dir(path).unwrap();
+        let file_manager = FileManager::with_base_dir(path, opts.num_shard).unwrap();
         let ctx = Arc::new(Context {
             file_manager,
             fn_registry: opts.fn_registry.take().unwrap(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,4 +30,6 @@ pub enum HelixError {
     IncompatibleLength(usize, usize),
     #[error("Helix is closed")]
     Closed,
+    #[error("Running into unreachable situation {0}")]
+    Unreachable(String),
 }

--- a/src/file/file_manager.rs
+++ b/src/file/file_manager.rs
@@ -160,24 +160,7 @@ impl FileManager {
         Ok(())
     }
 
-    crate async fn open_sstable(&self, tid: ThreadId, level_id: LevelId) -> Result<File> {
-        let filename = self.base_dir.join(format!(
-            "{}-{}-{}.{}",
-            "sst", tid, level_id, BINARY_FILE_EXTENSION,
-        ));
-
-        Ok(File::open(filename).await?)
-    }
-
-    crate async fn open_vlog(&self, tid: ThreadId, level_id: LevelId) -> Result<File> {
-        let filename = self.base_dir.join(format!(
-            "{}-{}-{}.{}",
-            "vlog", tid, level_id, BINARY_FILE_EXTENSION,
-        ));
-
-        Ok(File::open(filename).await?)
-    }
-
+    // todo: deprecate this.
     /// Open or create [LevelInfo].
     crate async fn open_level_info(&self) -> Result<LevelInfo> {
         let filename = self.base_dir.join(LEVEL_INFO_FILENAME);

--- a/src/file/file_manager.rs
+++ b/src/file/file_manager.rs
@@ -1,9 +1,16 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tracing::warn;
 
 use crate::error::Result;
 use crate::io::File;
 use crate::types::{Bytes, LevelId, LevelInfo, ThreadId};
+use crate::util::{AssertSend, AssertSync};
 
 const COMMON_FILE_PREFIX: &str = "helix";
 const COMMON_FILE_EXTENSION: &str = "hlx";
@@ -11,7 +18,7 @@ const BINARY_FILE_EXTENSION: &str = "bin";
 
 const LEVEL_INFO_FILENAME: &str = "LEVEL_INFO";
 
-pub enum FileType {
+crate enum FileType {
     Rick,
     VLog,
     SSTable,
@@ -31,24 +38,96 @@ impl FileType {
     }
 }
 
-pub enum OtherType {
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+crate enum FileNo {
+    LevelInfo,
+    Rick(LevelId),
+    SSTable(LevelId),
+}
+
+impl FileNo {
+    fn name(&self) -> String {
+        match self {
+            FileNo::LevelInfo => "LEVEL_INFO".to_string(),
+            FileNo::Rick(l_id) => format!("rick-{}.{}", l_id, BINARY_FILE_EXTENSION),
+            FileNo::SSTable(l_id) => format!("sst-{}.{}", l_id, BINARY_FILE_EXTENSION),
+        }
+    }
+}
+
+crate enum OtherType {
     /// Timestamp range of each level.
     LevelInfo,
     /// Thread Identifier.
     TId,
 }
 
-pub struct FileManager {
+#[derive(Clone)]
+struct RawFilePtr(Rc<File>);
+
+unsafe impl Send for RawFilePtr {}
+unsafe impl Sync for RawFilePtr {}
+
+/// Proxy for all file open/create operations.
+///
+/// It will keep opened file until a explicit garbage collection. So others
+/// needn't to close file.
+crate struct FileManager {
     base_dir: PathBuf,
+    // todo: GC. maybe do it when outdating some level.
+    fd_pool: Arc<Mutex<HashMap<(ThreadId, FileNo), RawFilePtr>>>,
 }
 
+impl AssertSync for FileManager {}
+impl AssertSend for FileManager {}
+
 impl FileManager {
-    pub fn with_base_dir<P: AsRef<Path>>(base_dir: P) -> Result<Self> {
+    pub fn with_base_dir<P: AsRef<Path>>(base_dir: P, shards: usize) -> Result<Self> {
         fs::create_dir_all(base_dir.as_ref())?;
+
+        // check dir
+        let dir_num = fs::read_dir(base_dir.as_ref())?
+            .map(|dir| Ok(dir?.file_type()?.is_dir()))
+            .collect::<Result<Vec<_>>>()?
+            .len();
+        if dir_num != shards {
+            warn!(
+                "Detected {} folder in {:?}, which isn't equal to given shard number {}",
+                dir_num,
+                base_dir.as_ref().to_str(),
+                shards
+            );
+        }
+
+        // create sub dir
+        for id in 0..shards {
+            match fs::create_dir(base_dir.as_ref().join(id.to_string())) {
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                other => other?,
+            }
+        }
 
         Ok(Self {
             base_dir: base_dir.as_ref().to_path_buf(),
+            fd_pool: Arc::default(),
         })
+    }
+
+    crate async fn open(&self, tid: ThreadId, file_no: FileNo) -> Result<Rc<File>> {
+        if let Some(file_ptr) = self.fd_pool.lock().await.get(&(tid, file_no)) {
+            return Ok(file_ptr.0.clone());
+        }
+
+        let name = file_no.name();
+        let path = self.base_dir.join(tid.to_string()).join(name);
+        let file = Rc::new(File::open(path).await?);
+        let cache_file = file.clone();
+        self.fd_pool
+            .lock()
+            .await
+            .insert((tid, file_no), RawFilePtr(cache_file));
+
+        Ok(file)
     }
 
     // might deprecate this.
@@ -122,6 +201,8 @@ impl FileManager {
 
 #[cfg(test)]
 mod test {
+    use std::os::unix::io::AsRawFd;
+
     use glommio::LocalExecutor;
     use tempfile::tempdir;
 
@@ -130,12 +211,30 @@ mod test {
     #[test]
     fn new_file_manager() {
         let ex = LocalExecutor::default();
-        ex.run(async {
-            let base_dir = tempdir().unwrap();
+        let base_dir = tempdir().unwrap();
+        let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
 
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+        ex.run(async {
             let _ = file_manager.open_rick(1).await.unwrap();
             assert_eq!(base_dir.path().read_dir().unwrap().count(), 1);
+        });
+    }
+
+    #[test]
+    fn reopen_file() {
+        let ex = LocalExecutor::default();
+        let base_dir = tempdir().unwrap();
+        let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
+
+        ex.run(async {
+            let info_file = file_manager.open(0, FileNo::LevelInfo).await.unwrap();
+            let first_fd = info_file.as_raw_fd();
+
+            drop(info_file);
+            let info_file = file_manager.open(0, FileNo::LevelInfo).await.unwrap();
+            let second_fd = info_file.as_raw_fd();
+
+            assert_eq!(first_fd, second_fd);
         });
     }
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -2,6 +2,6 @@ mod file_manager;
 mod rick;
 mod sstable;
 
-pub use file_manager::{FileManager, FileType};
+crate use file_manager::{FileManager, FileNo};
 pub use rick::Rick;
 pub use sstable::{IndexBlockBuilder, SSTable, TableBuilder};

--- a/src/file/rick.rs
+++ b/src/file/rick.rs
@@ -347,7 +347,7 @@ mod test {
 
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let rick_file = file_manager.open_rick(1).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
@@ -380,7 +380,7 @@ mod test {
 
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let rick_file = file_manager.open_rick(1).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
@@ -402,7 +402,7 @@ mod test {
 
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let rick_file = file_manager.open_rick(1).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
@@ -434,7 +434,7 @@ mod test {
 
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let rick_file = file_manager.open_rick(1).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 

--- a/src/file/rick.rs
+++ b/src/file/rick.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use std::time::Instant;
 use std::usize;
 
@@ -36,7 +37,7 @@ use crate::util::check_bytes_length;
 /// Rick can be either ordered or disordered, dependents on which level
 /// it sites.
 pub struct Rick {
-    file: File,
+    file: Rc<File>,
     sb: RickSuperBlock,
 }
 
@@ -47,7 +48,7 @@ impl Rick {
     /// file. If the rick file is not empty it will be ignored. If `None` is
     /// provided, the `value_format` field in super block will be set to
     /// default value, which is `RawValue`.
-    pub async fn open(file: File, value_format: Option<ValueFormat>) -> Result<Self> {
+    pub async fn open(file: Rc<File>, value_format: Option<ValueFormat>) -> Result<Self> {
         let sb = Self::read_super_block(&file, value_format).await?;
 
         Ok(Self { file, sb })
@@ -195,12 +196,6 @@ impl Rick {
         Ok(())
     }
 
-    pub async fn close(self) -> Result<()> {
-        self.file.close().await?;
-
-        Ok(())
-    }
-
     /// Recycle entries in given `range` by free them using `fallocate` syscall.
     ///
     /// The general procedure would be like:
@@ -340,6 +335,7 @@ mod test {
 
     use super::*;
     use crate::file::file_manager::FileManager;
+    use crate::file::FileNo;
 
     #[test]
     fn new_super_block() {
@@ -348,7 +344,7 @@ mod test {
         ex.run(async {
             let base_dir = tempdir().unwrap();
             let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
-            let rick_file = file_manager.open_rick(1).await.unwrap();
+            let rick_file = file_manager.open(0, FileNo::Rick(0)).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
             assert_eq!(RickSuperBlock::LENGTH, rick.start() as usize);
@@ -366,7 +362,8 @@ mod test {
 
             // close and open again
             drop(rick);
-            let rick_file = file_manager.open_rick(1).await.unwrap();
+            file_manager.close_some(0).await.unwrap();
+            let rick_file = file_manager.open(0, FileNo::Rick(0)).await.unwrap();
             let rick = Rick::open(rick_file, None).await.unwrap();
 
             assert_eq!(RickSuperBlock::LENGTH, rick.start() as usize);
@@ -381,7 +378,7 @@ mod test {
         ex.run(async {
             let base_dir = tempdir().unwrap();
             let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
-            let rick_file = file_manager.open_rick(1).await.unwrap();
+            let rick_file = file_manager.open(0, FileNo::Rick(0)).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
             let entry = Entry {
@@ -403,7 +400,7 @@ mod test {
         ex.run(async {
             let base_dir = tempdir().unwrap();
             let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
-            let rick_file = file_manager.open_rick(1).await.unwrap();
+            let rick_file = file_manager.open(0, FileNo::Rick(0)).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
             let entries = vec![
@@ -435,7 +432,7 @@ mod test {
         ex.run(async {
             let base_dir = tempdir().unwrap();
             let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
-            let rick_file = file_manager.open_rick(1).await.unwrap();
+            let rick_file = file_manager.open(0, FileNo::Rick(0)).await.unwrap();
             let mut rick = Rick::open(rick_file, None).await.unwrap();
 
             let mut entries = vec![

--- a/src/file/sstable.rs
+++ b/src/file/sstable.rs
@@ -4,7 +4,7 @@ use tracing::error;
 
 use crate::context::Context;
 use crate::error::{HelixError, Result};
-use crate::file::Rick;
+use crate::file::{FileNo, Rick};
 use crate::index::MemIndex;
 use crate::io::File;
 use crate::table::TableReadHandle;
@@ -44,7 +44,7 @@ impl SSTable {
         // open rick file
         let rick_file = ctx
             .file_manager
-            .open_vlog(self.sb.thread_id, self.sb.level_id)
+            .open(self.sb.thread_id, FileNo::Rick(self.sb.level_id))
             .await?;
         let rick = Rick::open(rick_file, None).await?;
 
@@ -263,7 +263,7 @@ mod test {
                 fn_registry: FnRegistry::new_noop(),
             });
             let mut table_builder =
-                TableBuilder::begin(1, 1, ctx.file_manager.open_sstable(1, 1).await.unwrap());
+                TableBuilder::begin(0, 1, ctx.file_manager.open_sstable(1, 1).await.unwrap());
             let mut index_bb = IndexBlockBuilder::new();
 
             let indices = vec![

--- a/src/file/sstable.rs
+++ b/src/file/sstable.rs
@@ -257,7 +257,7 @@ mod test {
         let ex = LocalExecutor::default();
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let ctx = Arc::new(Context {
                 file_manager,
                 fn_registry: FnRegistry::new_noop(),

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,4 @@
+use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::path::Path;
 
 use glommio::io::{DmaFile, OpenOptions};
@@ -69,5 +70,11 @@ impl File {
         self.0.close().await?;
 
         Ok(())
+    }
+}
+
+impl AsRawFd for File {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -734,7 +734,7 @@ mod test {
         let ex = LocalExecutor::default();
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let fn_registry = FnRegistry::new_noop();
             let ctx = Arc::new(Context {
                 file_manager,
@@ -798,7 +798,7 @@ mod test {
         let ex = LocalExecutor::default();
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
             let fn_registry = FnRegistry::new_noop();
             let ctx = Arc::new(Context {
                 file_manager,

--- a/src/level.rs
+++ b/src/level.rs
@@ -240,7 +240,7 @@ impl Levels {
                     let table_file = self
                         .ctx
                         .file_manager
-                        .open_sstable(self.tid, level_id)
+                        .open(self.tid, FileNo::SSTable(level_id))
                         .await?;
                     // table file is empty, means this level haven't finished it compaction. Need to
                     // read value from L0 rick.
@@ -264,7 +264,6 @@ impl Levels {
 
                 let entry = handle.get(time_key).await?;
                 let is_compressed = handle.is_compressed();
-                handle.try_close().await?;
                 // update cache
                 if let Some(mut entry) = entry {
                     if is_compressed {
@@ -370,7 +369,7 @@ impl Levels {
             level_id,
             self.ctx
                 .file_manager
-                .open_sstable(self.tid, level_id)
+                .open(self.tid, FileNo::SSTable(level_id))
                 .await?,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 #![feature(new_uninit)]
 #![feature(crate_visibility_modifier)]
+#![feature(hash_drain_filter)]
 // todo: open these lints
 #![allow(dead_code)]
 #![allow(unused_variables)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(async_closure)]
 #![feature(core_intrinsics)]
 #![feature(new_uninit)]
+#![feature(crate_visibility_modifier)]
 // todo: open these lints
 #![allow(dead_code)]
 #![allow(unused_variables)]

--- a/src/option.rs
+++ b/src/option.rs
@@ -64,10 +64,10 @@ impl Options {
     /// # use helixdb::option::Options;
     /// let options = Options::default();
     /// assert!(options.fn_registry.is_some());
-    /// // after calling `clone_partial()` some will be `None` because they won't be cloned actually.
-    /// let options_cloned = options.clone_partial();
-    /// assert!(options_cloned.fn_registry.is_none());
-    /// ```
+    /// // after calling `clone_partial()` some will be `None` because they
+    /// won't be cloned actually. let options_cloned =
+    /// options.clone_partial(); assert!(options_cloned.fn_registry.
+    /// is_none()); ```
     pub fn clone_partial(&self) -> Self {
         Self {
             num_shard: self.num_shard,

--- a/src/table.rs
+++ b/src/table.rs
@@ -70,7 +70,7 @@ impl TableReadHandle {
     }
 
     pub async fn close(self) -> Result<()> {
-        self.rick.close().await?;
+        // self.rick.close().await?;
         self.sstable.close().await?;
 
         Ok(())

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::context::Context;
@@ -67,24 +66,6 @@ impl TableReadHandle {
 
     pub fn is_compressed(&self) -> bool {
         self.rick.is_compressed()
-    }
-
-    pub async fn close(self) -> Result<()> {
-        // self.rick.close().await?;
-        self.sstable.close().await?;
-
-        Ok(())
-    }
-
-    /// Try to close this handle which is wrapped by `Rc`. This method will
-    /// only perform actually close when "this" is the last existing
-    /// reference.
-    pub async fn try_close(self: Rc<Self>) -> Result<()> {
-        if let Ok(handle) = Rc::try_unwrap(self) {
-            handle.close().await?;
-        }
-
-        Ok(())
     }
 
     // For test case.

--- a/src/types/level_info.rs
+++ b/src/types/level_info.rs
@@ -111,7 +111,7 @@ impl LevelInfo {
     }
 
     /// Return new level id.
-    pub async fn add_level(
+    crate async fn add_level(
         &mut self,
         start: Timestamp,
         end: Timestamp,
@@ -127,7 +127,7 @@ impl LevelInfo {
         Ok(next_id)
     }
 
-    pub async fn remove_last_level(&mut self, file_manager: &FileManager) -> Result<()> {
+    crate async fn remove_last_level(&mut self, file_manager: &FileManager) -> Result<()> {
         self.infos.pop_front();
 
         self.sync(file_manager).await
@@ -183,7 +183,7 @@ mod test {
         let ex = LocalExecutor::default();
         ex.run(async {
             let base_dir = tempdir().unwrap();
-            let file_manager = FileManager::with_base_dir(base_dir.path()).unwrap();
+            let file_manager = FileManager::with_base_dir(base_dir.path(), 1).unwrap();
 
             let mut info = LevelInfo::new(vec![]);
             info.add_level(0, 9, &file_manager).await.unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,3 +124,7 @@ pub fn check_bytes_length(data: &[u8], length: usize) -> Result<()> {
         Err(HelixError::IncompatibleLength(length, data.len()))
     }
 }
+
+crate trait AssertSend: Send {}
+
+crate trait AssertSync: Sync {}


### PR DESCRIPTION
Cache all opened files in file manager. Avoid opening one file too many times to run out of fd.

This also makes others needn't care about when to close the opened file. File manager will close unneeded when requesting. But this is a to-do item.