### PR TITLE
Add Compact Scheduler Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ flatbuffers = "2.0.0"
 io-uring = "0.5.0"
 tokio = { version = "1.4", features = ["full"] }
 glommio = "0.5.1"
-async-trait = "0.1.48"
+async-trait = "0.1.51"
 lru = "0.6"
 futures-util = "0.3"
 crossbeam-channel = "0.5"

--- a/src/compact_sched.rs
+++ b/src/compact_sched.rs
@@ -1,0 +1,97 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::{Rc, Weak};
+use std::time::Duration;
+
+use glommio::timer::TimerActionRepeat;
+use glommio::{Local, TaskQueueHandle};
+
+use crate::error::Result;
+use crate::level::Levels;
+use crate::types::LevelId;
+
+crate trait CompactScheduler {
+    fn enqueue(&self);
+}
+
+crate struct QueueUpCompSched {
+    is_compacting: RefCell<bool>,
+    interval: Duration,
+    queue: RefCell<VecDeque<LevelId>>,
+    delay_num: usize,
+    levels: Weak<Levels>,
+    tq: TaskQueueHandle,
+}
+
+impl QueueUpCompSched {
+    crate fn new(
+        interval: Duration,
+        delay_num: usize,
+        levels: Weak<Levels>,
+        tq: TaskQueueHandle,
+    ) -> Self {
+        Self {
+            is_compacting: RefCell::new(false),
+            interval,
+            queue: RefCell::new(VecDeque::new()),
+            delay_num,
+            levels,
+            tq,
+        }
+    }
+
+    crate fn enqueue(&self, l_id: LevelId) {
+        self.queue.borrow_mut().push_back(l_id);
+    }
+
+    crate async fn schedule(self: Rc<Self>) -> Option<Duration> {
+        if *self.is_compacting.borrow() || self.queue.borrow().len() < self.delay_num {
+            return Some(self.interval);
+        }
+
+        let level_id = self.queue.borrow_mut().pop_front().unwrap();
+        *self.is_compacting.borrow_mut() = true;
+
+        let levels = self.levels.clone();
+        Local::local_into(
+            async move {
+                // todo: propagate Error?
+                let _ = levels.upgrade().unwrap().compact_level(level_id);
+            },
+            self.tq,
+        )
+        .unwrap()
+        .detach();
+
+        Some(self.interval)
+    }
+
+    crate fn install(self: Rc<Self>, tq: TaskQueueHandle) -> Result<()> {
+        let sched = self.clone();
+        TimerActionRepeat::repeat_into(move || sched.clone().schedule(), tq)?;
+
+        Ok(())
+    }
+
+    /// For writing mock test.
+    ///
+    /// # Panic
+    /// `levels` in the returning object is not initialize (an empty `Weak`).
+    /// Any operations make this to call `levels` will panic due to
+    /// the attempt of trying to upgrade that empty weak pointer.
+    #[cfg(test)]
+    crate fn default() -> Self {
+        Self {
+            is_compacting: RefCell::new(false),
+            interval: Duration::from_secs(1),
+            queue: RefCell::new(VecDeque::new()),
+            delay_num: 3,
+            levels: Weak::new(),
+            tq: Local::create_task_queue(
+                glommio::Shares::default(),
+                glommio::Latency::NotImportant,
+                "test_comp_tq",
+            ),
+        }
+    }
+}

--- a/src/compact_sched.rs
+++ b/src/compact_sched.rs
@@ -32,7 +32,7 @@ crate struct QueueUpCompSched {
     interval: Duration,
     queue: RefCell<VecDeque<LevelId>>,
     delay_num: usize,
-    levels: Weak<Levels>,
+    levels: Weak<Levels<Self>>,
     tq: TaskQueueHandle,
 }
 
@@ -40,7 +40,7 @@ impl QueueUpCompSched {
     crate fn new(
         interval: Duration,
         delay_num: usize,
-        levels: Weak<Levels>,
+        levels: Weak<Levels<Self>>,
         tq: TaskQueueHandle,
     ) -> Self {
         Self {

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,6 @@ use crate::file::FileManager;
 use crate::fn_registry::FnRegistry;
 
 pub struct Context {
-    crate file_manager: FileManager,
     pub fn_registry: FnRegistry,
+    crate file_manager: FileManager,
 }

--- a/src/io_worker.rs
+++ b/src/io_worker.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
 use glommio::channels::channel_mesh::{
@@ -7,12 +7,13 @@ use glommio::channels::channel_mesh::{
     Senders as ChannelMeshSender,
 };
 use glommio::sync::Gate;
-use glommio::Task as GlommioTask;
+use glommio::{Latency, Local, Shares, Task as GlommioTask};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::oneshot::Sender as Notifier;
 use tokio::sync::Mutex;
 use tracing::trace;
 
+use crate::compact_sched::QueueUpCompSched;
 use crate::context::Context;
 use crate::error::Result;
 use crate::level::{Levels, TimestampReviewer};
@@ -46,13 +47,23 @@ impl IOWorker {
         ctx: Arc<Context>,
         ts_action_sender: ChannelMeshSender<TimestampAction>,
     ) -> Result<Self> {
+        let level_weak = Weak::new();
+        let compact_task_queue =
+            Local::create_task_queue(Shares::default(), Latency::NotImportant, "compact_tq");
+        let sched = Rc::new(QueueUpCompSched::new(
+            opts.compact_prompt_interval,
+            2,
+            level_weak,
+            compact_task_queue,
+        ));
         let levels = Levels::try_new(
             tid,
-            opts,
+            opts.clone(),
             timestamp_reviewer,
             ctx,
             ts_action_sender,
             level_info,
+            sched,
         )
         .await?;
 
@@ -132,6 +143,14 @@ impl IOWorker {
                 }
             }
         }
+    }
+
+    fn install_comp_sched(&self, sched: Rc<QueueUpCompSched>) -> Result<()> {
+        let compact_task_queue =
+            Local::create_task_queue(Shares::default(), Latency::NotImportant, "compact_tq");
+        sched.install(compact_task_queue)?;
+
+        Ok(())
     }
 }
 

--- a/src/io_worker.rs
+++ b/src/io_worker.rs
@@ -35,7 +35,7 @@ thread_local!(
 /// A un-Send handle to accept and process requests.
 pub struct IOWorker {
     tid: ThreadId,
-    levels: Rc<Levels>,
+    levels: Rc<Levels<QueueUpCompSched>>,
     // todo: maybe add channel mesh for scan
 }
 

--- a/src/level.rs
+++ b/src/level.rs
@@ -758,6 +758,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "temp"]
     fn put_get_on_rick() {
         let ex = LocalExecutor::default();
         ex.run(async {
@@ -823,6 +824,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "temp"]
     fn put_get_with_compaction() {
         let ex = LocalExecutor::default();
         ex.run(async {

--- a/src/level.rs
+++ b/src/level.rs
@@ -758,7 +758,6 @@ mod test {
     }
 
     #[test]
-    #[ignore = "temp"]
     fn put_get_on_rick() {
         let ex = LocalExecutor::default();
         ex.run(async {
@@ -775,6 +774,7 @@ mod test {
             let level_info = Arc::new(Mutex::new(
                 ctx.file_manager.open_level_info().await.unwrap(),
             ));
+            let (sched, tq) = QueueUpCompSched::default();
             let levels = Levels::try_new(
                 0,
                 Options::default(),
@@ -782,10 +782,12 @@ mod test {
                 ctx,
                 sender,
                 level_info,
-                Rc::new(QueueUpCompSched::default()),
+                sched.clone(),
             )
             .await
             .unwrap();
+            sched.clone().init(levels.clone());
+            sched.install(tq).unwrap();
 
             let entries = vec![
                 (1, b"key1".to_vec(), b"value1".to_vec()).into(),
@@ -824,7 +826,6 @@ mod test {
     }
 
     #[test]
-    #[ignore = "temp"]
     fn put_get_with_compaction() {
         let ex = LocalExecutor::default();
         ex.run(async {
@@ -841,6 +842,7 @@ mod test {
             let level_info = Arc::new(Mutex::new(
                 ctx.file_manager.open_level_info().await.unwrap(),
             ));
+            let (sched, tq) = QueueUpCompSched::default();
             let levels = Levels::try_new(
                 0,
                 Options::default(),
@@ -848,10 +850,12 @@ mod test {
                 ctx.clone(),
                 sender,
                 level_info,
-                Rc::new(QueueUpCompSched::default()),
+                sched.clone(),
             )
             .await
             .unwrap();
+            sched.clone().init(levels.clone());
+            sched.install(tq).unwrap();
 
             for timestamp in 0..25 {
                 levels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ macro_rules! ok_unwrap {
 #[deprecated]
 mod blocks;
 mod cache;
+mod compact_sched;
 mod context;
 mod db;
 mod error;

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::cache::CacheConfig;
 use crate::fn_registry::FnRegistry;
 use crate::level::{SimpleTimestampReviewer, TimestampReviewer, WriteBatchConfig};
@@ -15,12 +17,15 @@ pub struct Options {
     pub(crate) cache: CacheConfig,
     ///
     pub(crate) write_batch: WriteBatchConfig,
+    ///
+    pub(crate) compact_prompt_interval: Duration,
 
     // helixdb context
     pub(crate) fn_registry: Option<FnRegistry>,
     pub(crate) tsr: Option<Box<dyn TimestampReviewer>>,
 }
 
+// todo: remove this
 impl Clone for Options {
     /// a
     fn clone(&self) -> Self {
@@ -29,6 +34,7 @@ impl Clone for Options {
             task_buffer_size: self.task_buffer_size,
             cache: self.cache,
             write_batch: self.write_batch,
+            compact_prompt_interval: self.compact_prompt_interval,
 
             fn_registry: None,
             tsr: None,
@@ -43,6 +49,7 @@ impl Options {
             task_buffer_size: 128,
             cache: CacheConfig::default(),
             write_batch: WriteBatchConfig::default(),
+            compact_prompt_interval: Duration::from_secs(1),
 
             fn_registry: Some(FnRegistry::new_noop()),
             tsr: Some(Box::new(SimpleTimestampReviewer::new(1024, 1024 * 8))),
@@ -74,6 +81,7 @@ impl Options {
             task_buffer_size: self.task_buffer_size,
             cache: self.cache,
             write_batch: self.write_batch,
+            compact_prompt_interval: self.compact_prompt_interval,
 
             fn_registry: None,
             tsr: None,
@@ -113,6 +121,11 @@ impl Options {
 
     pub fn set_task_buffer_size(mut self, buffer_size: usize) -> Self {
         self.task_buffer_size = buffer_size;
+        self
+    }
+
+    pub fn set_compact_prompt_interval(mut self, interval: Duration) -> Self {
+        self.compact_prompt_interval = interval;
         self
     }
 }


### PR DESCRIPTION
This PR adds a trait `CompactScheduler` and a dumb implementation `QueueUpCompSched`.

`QueueUpCompSched` will cause a cyclic reference: both it and `Levels` keep each other's `Rc`.
Channel or `Weak` ref is a better choice.

Currently, only the interface is included. `Levels`' new compact procedure is vacant.